### PR TITLE
Parallelism in event loop

### DIFF
--- a/src/main/java/org/jordi/CryptoConverterMain.java
+++ b/src/main/java/org/jordi/CryptoConverterMain.java
@@ -2,11 +2,15 @@ package org.jordi;
 
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
+import io.smallrye.mutiny.Multi;
 import jakarta.inject.Inject;
 import org.jordi.client.TickerResource;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @QuarkusMain
 public class CryptoConverterMain implements QuarkusApplication {
@@ -15,28 +19,49 @@ public class CryptoConverterMain implements QuarkusApplication {
 
     @Override
     public int run(String... args) throws Exception {
+        if (args.length == 0) {
+            System.err.println("Please provide at least one cryptocurrency symbol as argument (e.g., BTC ETH DOGE)");
+            return 1;
+        }
+        List<String> currencies = Arrays.asList(args);
         CountDownLatch latch = new CountDownLatch(1);
+        AtomicInteger errorCount = new AtomicInteger(0);
+        AtomicInteger successCount = new AtomicInteger(0);
 
-        tickerResource.getTicker("BTC")
+        Multi.createFrom().iterable(currencies)
+                .onItem().transformToUniAndMerge(currency ->
+                        tickerResource.getTicker(currency)
+                                .onItem().invoke(response -> {
+                                    System.out.printf("[%s] SUCCESS: %s%n",
+                                            Thread.currentThread().getName(),
+                                            response);
+                                    successCount.incrementAndGet();
+                                })
+                                .onFailure().invoke(throwable -> {
+                                    System.err.printf("[%s] ERROR for %s: %s%n",
+                                            Thread.currentThread().getName(),
+                                            currency, throwable.getMessage());
+                                    errorCount.incrementAndGet();
+                                })
+                                .onFailure().recoverWithNull() // Continue with other currencies even if one fails
+                )
+                .collect().asList()
                 .subscribe().with(
-                        response -> {
-                            System.out.println("=== SUCCESS ===");
-                            System.out.println("Response: " + response);
-                            System.out.println("===============");
+                        results -> {
+                            System.out.println("=".repeat(50));
+                            System.out.printf("Completed: %d successful, %d errors%n",
+                                    successCount.get(), errorCount.get());
                             latch.countDown();
                         },
                         failure -> {
-                            System.err.println("=== FAILURE ===");
-                            System.err.println("Error: " + failure.getMessage());
-                            failure.printStackTrace();
-                            System.err.println("===============");
+                            System.err.println("Overall failure: " + failure.getMessage());
                             latch.countDown();
                         }
                 );
 
-        boolean completed = latch.await(10, TimeUnit.SECONDS);
+        boolean completed = latch.await(15, TimeUnit.SECONDS);
         if (!completed) {
-            System.err.println("Request timed out after 10 seconds");
+            System.err.println("Some requests timed out after 15 seconds");
             return 1;
         }
 


### PR DESCRIPTION
# Summary of Changes

## Support for Multiple Cryptocurrencies:

* The main method now accepts multiple cryptocurrency symbols as command-line arguments (e.g., BTC ETH DOGE).
It checks if any arguments are provided; if not, it prints an error and exits.
Reactive Processing with Multi:

* Instead of fetching only "BTC" using a single call, the code uses SmallRye Mutiny’s Multi to process all provided currencies in parallel/asynchronously.
Each currency is passed to tickerResource.getTicker(currency), and results are handled reactively.

* Result Handling:

**On success**: Prints a success message including the thread name and response, increments a success counter.
**On failure**: Prints an error message including the thread name and error, increments an error counter.
Continues processing other currencies even if one fails (recoverWithNull).

* Completion and Reporting:

After all requests complete, prints a summary of how many succeeded and failed.
Timeout for completion has been increased from 10 to 15 seconds, and the timeout message updated accordingly.
Other Minor Refactors:

Uses AtomicInteger for thread-safe success/error counting.
Improved output formatting.